### PR TITLE
UsersテーブルをAccountsテーブルに変更する

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import firebase from './firebase'
 
 import Sequelize from 'sequelize'
 import sequelize from './sequelize'
-import Users from './models/users'
+import Accounts from './models/accounts'
 
 const app = express()
 
@@ -30,7 +30,7 @@ app.post('/authentication', async (request, response) => {
   // Firebase に問い合わせる
   const verified = await firebase.auth().verifyIdToken(firebaseIdToken)
 
-  const alreadyRegistered = await Users.find({
+  const alreadyRegistered = await Accounts.find({
     where: {
       firebase_id: {
         [Sequelize.Op.eq]: verified.uid
@@ -40,7 +40,7 @@ app.post('/authentication', async (request, response) => {
 
   if (alreadyRegistered === null) {
     try {
-      const user = Users.build({
+      const user = Accounts.build({
         name: verified.name,
         firebase_id: verified.uid,
         access_token: accessToken,

--- a/src/models/accounts.ts
+++ b/src/models/accounts.ts
@@ -1,11 +1,11 @@
 import { Sequelize, Table, Column, Model, AllowNull, PrimaryKey, AutoIncrement, Unique, CreatedAt, UpdatedAt, IsUUID, Default } from 'sequelize-typescript'
 
 @Table({
-  tableName: 'users',
+  tableName: 'accounts',
   timestamps: true,
   paranoid: true
 })
-export default class Users extends Model<Users> {
+export default class Accounts extends Model<Accounts> {
   @PrimaryKey
   @AutoIncrement
 	@Column

--- a/src/sequelize.ts
+++ b/src/sequelize.ts
@@ -1,9 +1,9 @@
 import { Sequelize } from 'sequelize-typescript'
 import * as Constants from './constants'
-import Users from './models/users'
+import Accounts from './models/accounts'
 
 const sequelize = new Sequelize(Constants.SEQUELIZE_CONFIG)
 
-sequelize.addModels([Users])
+sequelize.addModels([Accounts])
 
 export default sequelize


### PR DESCRIPTION
<!-- 必ずしも全ての項目を埋めなくてよい -->

# 概要
Users は Twitter のユーザのユーザを管理するテーブル名として使用したいため，Accounts というテーブル名に変更してそこでアカウントを管理するようにする．

# 変更内容
<!--
ビューの変更がある場合はスクリーンショットによる比較などがあるとわかりやすい

|変更前|変更後|
|:-:|:-:|
|変更なし|変更なし|
-->

# 影響範囲
<!--
この関数を変更したのでこの機能にも影響があるなど
-->

# 動作要件
<!--
動作に必要な環境変数や依存関係，データベースの更新など
-->

# 補足
<!--
レビューをする際に注意するべき点，ローカル環境で試す際の注意点など
-->
